### PR TITLE
Use the correct parameter for Google API key

### DIFF
--- a/omgeo/services/google.py
+++ b/omgeo/services/google.py
@@ -27,7 +27,7 @@ class Google(GeocodeService):
     def _geocode(self, pq):
         params = {
             'address': pq.query,
-            'api_key': self._settings['api_key']
+            'key': self._settings['api_key']
         }
 
         if pq.country:


### PR DESCRIPTION
URL parameter for specifying API key was incorrect.

https://developers.google.com/maps/documentation/geocoding/start

Trivial, merging.