### PR TITLE
Update US Census API base url to use HTTPS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -171,4 +171,9 @@ v1.9.2, 2017-03-06
  * Fix Google geocoder API key parameter.
 
 v2.0.0, 2017-06-29
+------------------
  * Remove usage of the ESRI WGS geocoder find endpoint.
+
+Upcoming Release
+----------------
+ * Change Census geocoder to use HTTPS

--- a/omgeo/services/us_census.py
+++ b/omgeo/services/us_census.py
@@ -11,7 +11,7 @@ class USCensus(GeocodeService):
 
     # set endpoint based on whether we geocode by single-line address, or with keyed components
     _endpoint = ''
-    _endpoint_base = 'http://geocoding.geo.census.gov/geocoder/locations/'
+    _endpoint_base = 'https://geocoding.geo.census.gov/geocoder/locations/'
 
     def _geocode(self, pq):
         query = {


### PR DESCRIPTION
According to the US Census: 

> To improve security and privacy, and by federal government mandate, the U.S. Census Bureau will stop receiving Application Programming Interface (API) calls at http://api.census.gov/data/ on August 28, 2017.

This PR updates the base URL to use HTTPS. The API does not appear to have changed.