### PR TITLE
Covert EsriWGS to use HTTPS transport

### DIFF
--- a/omgeo/services/__init__.py
+++ b/omgeo/services/__init__.py
@@ -1,5 +1,5 @@
 from .bing import Bing
-from .esri import EsriWGS, EsriWGSSSL
+from .esri import EsriWGS
 from .us_census import USCensus
 from .mapquest import MapQuest, MapQuestSSL
 from .nominatim import Nominatim

--- a/omgeo/services/esri.py
+++ b/omgeo/services/esri.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class EsriWGS(GeocodeService):
     """
     Class to geocode using the `ESRI World Geocoding service
-    <http://geocode.arcgis.com/arcgis/geocoding.html>`_.
+    <https://developers.arcgis.com/features/geocoding/>`_.
 
     This uses two endpoints -- one for single-line addresses,
     and one for multi-part addresses.
@@ -73,7 +73,7 @@ class EsriWGS(GeocodeService):
         GroupBy(('x', 'y')),
     ]
 
-    _endpoint = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer'
+    _endpoint = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer'
 
     def __init__(self, preprocessors=None, postprocessors=None, settings=None):
         preprocessors = EsriWGS.DEFAULT_PREPROCESSORS if preprocessors is None else preprocessors
@@ -98,7 +98,7 @@ class EsriWGS(GeocodeService):
         :returns: list of location Candidates
         """
         #: List of desired output fields
-        #: See `ESRI docs <http://geocode.arcgis.com/arcgis/geocoding.html#output>_` for details
+        #: See `ESRI docs <https://developers.arcgis.com/rest/geocode/api-reference/geocoding-geocode-addresses.htm>_` for details
         outFields = ('Loc_name',
                      # 'Shape',
                      'Score',
@@ -251,13 +251,3 @@ class EsriWGS(GeocodeService):
         response_obj = self._get_json_obj(endpoint, query, is_post=True)
 
         return response_obj['access_token']
-
-
-class EsriWGSSSL(EsriWGS):
-    """
-    Class to geocode using the `ESRI World Geocoding service over SSL
-    <https://geocode.arcgis.com/arcgis/geocoding.html>`_.
-
-    See :class:`.EsriWGS` for detailed documentation.
-    """
-    _endpoint = 'https://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer'


### PR DESCRIPTION
Convert the Esri World Geocoding Service (`EsriWGS`) so that it uses HTTPS transport instead of HTTP. In the process, remove `EsriWGSSSL` and update some stray broken links.

---

**Testing**

See that test suite still passes: https://travis-ci.org/azavea/python-omgeo/builds/264788080

Also, I manually inspected the HTTPS endpoints for the API and they appear to return a valid certificate for the domain:

<img width="1004" alt="screen shot 2017-08-15 at 11 02 28" src="https://user-images.githubusercontent.com/43639/29321689-4181beba-81a9-11e7-926c-7686ca179a83.png">

Is there something else I'm missing to support HTTPS as the default?