### PR TITLE
Add Python 3 support and fix failing test for Google country filter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 python:
   - '2.7'
+  - '3.6'
 
 script:
   - python setup.py test
@@ -15,5 +16,6 @@ deploy:
     secure: Wc/aboeIntZeqgCSIOrd/66vceukY/KmdSLwcLB9gn7kRWRqOM+HiEX9+lJe4IKtMisz3zgRqZNAFJU/UUBBwuclHpbtQtV0FCQOFXEwUHQfouzAvVu/3C4fBgQeoet5KrJFo7OVUmYwyWPm8vJzWIraQWVfsR9Gv/AQBQdfuec=
   on:
     tags: true
+    python: '3.6'
     distributions: sdist bdist_wheel
     repo: azavea/python-omgeo

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,7 @@ v1.3.4, 2012-05-11
  * Add test for SnapPoints postprocessor.
  * Change __unicode__() method for places.Candidate to display info
    indicating null or empty values, instead of just displaying "None".
-   
+
 v1.3.5, 2012-05-21
 ------------------
  * Geocoder().geocode() method can take one-line string OR PlaceQuery instance.
@@ -60,11 +60,11 @@ v1.3.6, 2012-05-22
 ------------------
  * Add SSH support for MapQuest
  * Add CancelIfRegexInAttr preprocessor to avoid geocoding attempts if
-   a PlaceQuery instance attribute matches the given regex (such as a 
+   a PlaceQuery instance attribute matches the given regex (such as a
    PO Box)
  * Add timeout option that can be included in the GeocodeService settings
    parameter. There is now a default timeout of 10 seconds.
- 
+
 v1.3.7, 2012-05-23
 ------------------
  * Add CancelIfPOBox preprocessor and tests
@@ -145,7 +145,7 @@ v1.6.0, 2013-10-31
  * Add subregion and neighborhood parameters to queries
  * Allow HTTP request headers to be specified in geocoder settings
  * Documentation updates
- 
+
 v1.7.0, 2014-05-12
 ------------------
  * Add Census geocoder

--- a/README.rst
+++ b/README.rst
@@ -20,15 +20,15 @@ supported geocoders:
 
 **Documentation**
 
-Docs are available in `HTML <http://python-omgeo.readthedocs.org/en/latest/>`_ 
+Docs are available in `HTML <http://python-omgeo.readthedocs.org/en/latest/>`_
 or `PDF <http://media.readthedocs.org/pdf/python-omgeo/latest/python-omgeo.pdf>`_ format.
 
 **Usage Example**
 
 Make a new geocoder and geocode and address::
 
-    >>> from omgeo import Geocoder 
-    >>> g = Geocoder() 
+    >>> from omgeo import Geocoder
+    >>> g = Geocoder()
     >>> result = g.geocode('340 12th St, Philadelphia PA')
 
 Take a look at the result::

--- a/omgeo/geocoder.py
+++ b/omgeo/geocoder.py
@@ -98,7 +98,7 @@ class Geocoder():
 
         start_time = time.time()
         waterfall = self.waterfall if waterfall is None else waterfall
-        if type(pq) in (str, unicode):
+        if type(pq) in (str, str):
             pq = PlaceQuery(pq)
         processed_pq = copy.copy(pq)
 

--- a/omgeo/places.py
+++ b/omgeo/places.py
@@ -16,13 +16,13 @@ class Viewbox():
         :arg wkid: Well-known ID for spatial reference system (default ``4326``)
         """
         bounds = left, right, bottom, top
-        if not all([isinstance(x, (int, long, float)) for x in bounds]):
+        if not all([isinstance(x, (int, float)) for x in bounds]):
             raise ValueError('One or more bounds (%s) is not a real number.' % bounds)
         if left > right:
             raise ValueError('Left x-coord must be less than right x-coord.')
         if bottom > top:
             raise ValueError('Bottom y-coord must be less than top y-coord.')
-        for k in locals().keys():
+        for k in list(locals().keys()):
             if k != 'self':
                 setattr(self, k, locals()[k])
 
@@ -150,7 +150,7 @@ class PlaceQuery():
                           would be returned as "Vereinigte Staaten Von Amerika"
                           instead of "United States".
     """
-        for k in locals().keys():
+        for k in list(locals().keys()):
             if k not in ['self', 'kwargs']:
                 setattr(self, k, locals()[k])
         if query == '' and address == '' and city == '' and state == '' and postal == '':
@@ -206,7 +206,7 @@ class Candidate():
         return these values.
         """
 
-        for k in locals().keys():
+        for k in list(locals().keys()):
             if k not in ['self', 'kwargs']:
                 setattr(self, k, locals()[k])
         for k in kwargs:

--- a/omgeo/postprocessors.py
+++ b/omgeo/postprocessors.py
@@ -403,7 +403,7 @@ class DupePicker(_PostProcessor):
     def process(self, candidates):
         def cleanup(str_):
             """Returns string in uppercase and free of commas."""
-            if type(str_) in [str, unicode]:
+            if type(str_) in [str, str]:
                 return str_.replace(',', '').upper()
             return str_
 

--- a/omgeo/preprocessors.py
+++ b/omgeo/preprocessors.py
@@ -200,14 +200,14 @@ class CancelIfRegexInAttr(_PreProcessor):
         :arg bool ignorecase: set to ``False`` for a case-sensitive match (default ``True``)
         """
         regex_type = type(regex)
-        if type(regex) not in (str, unicode):
+        if type(regex) not in (str, str):
             raise Exception('First param "regex" must be a regex of type'
                             ' str or unicode, not %s.' % regex_type)
         attrs_type = type(attrs)
         if attrs_type not in (list, tuple):
             raise Exception('Second param "attrs" must be a list or tuple'
                             ' of PlaceQuery attributes, not %s.' % attrs_type)
-        if any(type(attr) not in (str, unicode) for attr in attrs):
+        if any(type(attr) not in (str, str) for attr in attrs):
             raise Exception('All given PlaceQuery attributes must be strings.')
         self.attrs = attrs
         if ignorecase:

--- a/omgeo/services/base.py
+++ b/omgeo/services/base.py
@@ -4,8 +4,8 @@ from json import loads
 import logging
 import socket
 from traceback import format_exc
-from urllib import urlencode
-from urllib2 import urlopen, Request
+from urllib.parse import urlencode
+from urllib.request import urlopen, Request
 from xml.dom import minidom
 
 logger = logging.getLogger(__name__)

--- a/omgeo/services/base.py
+++ b/omgeo/services/base.py
@@ -4,9 +4,16 @@ from json import loads
 import logging
 import socket
 from traceback import format_exc
-from urllib.parse import urlencode
-from urllib.request import urlopen, Request
 from xml.dom import minidom
+
+try:
+    # python 3
+    from urllib.parse import urlencode
+    from urllib.request import urlopen, Request
+except ImportError:
+    # python 2
+    from urllib import urlencode
+    from urllib2 import urlopen, Request
 
 logger = logging.getLogger(__name__)
 

--- a/omgeo/services/bing.py
+++ b/omgeo/services/bing.py
@@ -1,4 +1,4 @@
-from base import GeocodeService
+from .base import GeocodeService
 import logging
 from omgeo.places import Candidate
 from omgeo.preprocessors import ReplaceRangeWithNumber

--- a/omgeo/services/google.py
+++ b/omgeo/services/google.py
@@ -54,7 +54,7 @@ class Google(GeocodeService):
             'postal': {'type': 'postal_code', 'key': 'long_name'},
             'country': {'type': 'country', 'key': 'short_name'},
         }
-        for (field, lookup) in component_lookups.iteritems():
+        for (field, lookup) in component_lookups.items():
             setattr(candidate, 'match_' + field, self._get_component_from_result(result, lookup))
         candidate.geoservice = self.__class__.__name__
         return candidate

--- a/omgeo/services/mapquest.py
+++ b/omgeo/services/mapquest.py
@@ -2,7 +2,13 @@ from .base import GeocodeService
 import json
 import logging
 from omgeo.places import Candidate
-from urllib.parse import unquote
+
+try:
+    # python 3
+    from urllib.parse import unquote
+except ImportError:
+    # python 2
+    from urllib import unquote
 
 logger = logging.getLogger(__name__)
 

--- a/omgeo/services/mapquest.py
+++ b/omgeo/services/mapquest.py
@@ -1,8 +1,8 @@
-from base import GeocodeService
+from .base import GeocodeService
 import json
 import logging
 from omgeo.places import Candidate
-from urllib import unquote
+from urllib.parse import unquote
 
 logger = logging.getLogger(__name__)
 

--- a/omgeo/services/mapzen.py
+++ b/omgeo/services/mapzen.py
@@ -2,8 +2,14 @@ from .base import GeocodeService
 import logging
 from omgeo.places import Candidate
 from omgeo.preprocessors import ReplaceRangeWithNumber
-from urllib.parse import urljoin
 from posixpath import join as posixjoin
+
+try:
+    # python 3
+    from urllib.parse import urljoin
+except ImportError:
+    # python 2
+    from urlparse import urljoin
 
 logger = logging.getLogger(__name__)
 

--- a/omgeo/services/mapzen.py
+++ b/omgeo/services/mapzen.py
@@ -1,8 +1,8 @@
-from base import GeocodeService
+from .base import GeocodeService
 import logging
 from omgeo.places import Candidate
 from omgeo.preprocessors import ReplaceRangeWithNumber
-from urlparse import urljoin
+from urllib.parse import urljoin
 from posixpath import join as posixjoin
 
 logger = logging.getLogger(__name__)

--- a/omgeo/services/nominatim.py
+++ b/omgeo/services/nominatim.py
@@ -1,4 +1,4 @@
-from base import GeocodeService
+from .base import GeocodeService
 import logging
 from omgeo.places import Candidate
 from omgeo.preprocessors import ReplaceRangeWithNumber

--- a/omgeo/services/us_census.py
+++ b/omgeo/services/us_census.py
@@ -1,6 +1,6 @@
 import re
 
-from base import GeocodeService
+from .base import GeocodeService
 import logging
 from omgeo.places import Candidate
 

--- a/omgeo/tests/tests.py
+++ b/omgeo/tests/tests.py
@@ -343,7 +343,7 @@ class GeocoderTest(OmgeoTestCase):
 
     @unittest.skipIf(GOOGLE_API_KEY is None, GOOGLE_KEY_REQUIRED_MSG)
     def test_google_country_filter(self):
-        candidates = self.g_google.get_candidates('York')
+        candidates = self.g_google.get_candidates(PlaceQuery('York', country='US'))
         self.assertOneCandidate(candidates)
         self.assertEqual(candidates[0].match_region, 'PA')
         candidates = self.g_google.get_candidates(PlaceQuery('York', country='UK'))

--- a/omgeo/tests/tests.py
+++ b/omgeo/tests/tests.py
@@ -314,11 +314,10 @@ class GeocoderTest(OmgeoTestCase):
             else:
                 queries_with_results += 1
                 logger.info('Input:  %s' % self.pq[place].query)
-                logger.info(map(lambda c: 'Output: %r (%s %s)\n' %
+                logger.info(['Output: %r (%s %s)\n' %
                                 (c.match_addr,
                                  c.geoservice,
-                                 [c.locator, c.score, c.confidence, c.entity]),
-                                candidates))
+                                 [c.locator, c.score, c.confidence, c.entity]) for c in candidates])
         self.assertEqual(expected_results, queries_with_results,
                          'Got results for %d of %d queries.' % (queries_with_results, len(self.pq)))
 

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'python-omgeo'
-copyright = u'2012-2013 Azavea'
+project = 'python-omgeo'
+copyright = '2012-2013 Azavea'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -185,8 +185,8 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'python-omgeo.tex', u'python-omgeo Documentation',
-   u'Azavea Inc.', 'manual'),
+  ('index', 'python-omgeo.tex', 'python-omgeo Documentation',
+   'Azavea Inc.', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -215,8 +215,8 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'python-omgeo', u'python-omgeo Documentation',
-     [u'Andrew Jennings, Joseph Tricarico, Justin Walgran'], 1)
+    ('index', 'python-omgeo', 'python-omgeo Documentation',
+     ['Andrew Jennings, Joseph Tricarico, Justin Walgran'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -229,8 +229,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'python-omgeo', u'python-omgeo Documentation',
-   u'Andrew Jennings, Joseph Tricarico, Justin Walgran', 'python-omgeo', 'One line description of project.',
+  ('index', 'python-omgeo', 'python-omgeo Documentation',
+   'Andrew Jennings, Joseph Tricarico, Justin Walgran', 'python-omgeo', 'One line description of project.',
    'Miscellaneous'),
 ]
 


### PR DESCRIPTION
Test disambiguation of a place name with country name; do not assume default country selection.
Fixes a test that fails when the Google geocoder key is set.
Fixes #45.

Add Python 3 support by running `2to3` and adding backwards support for Python 2 in imports. Adds python 3 to test matrix run on Travis.

Closes #16
Connects #43 