### PR TITLE
Exclude people/businesses from geocoding with the Google service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - '3.6'
 
 script:
+  - python setup.py flake8
   - python setup.py test
 
 deploy:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -200,3 +200,8 @@ v5.0.0, 2018-03-29
 v5.1.0, 2018-06-19
 ------------------
  * Add HTTP/S support via Requests library
+
+v6.0.0, 2018-06-19
+------------------
+ * Exclude people/business results from the Google service. This is a *breaking
+   change*.

--- a/omgeo/__init__.py
+++ b/omgeo/__init__.py
@@ -1,1 +1,1 @@
-from .geocoder import Geocoder
+from .geocoder import Geocoder  # NOQA

--- a/omgeo/geocoder.py
+++ b/omgeo/geocoder.py
@@ -2,7 +2,6 @@ import copy
 import logging
 from omgeo.places import PlaceQuery
 from omgeo.postprocessors import DupePicker, SnapPoints
-import time
 
 logger = logging.getLogger(__name__)
 stats_logger = logging.getLogger('omgeo.stats')
@@ -13,9 +12,10 @@ class Geocoder():
     Class for building a custom geocoder using external APIs.
     """
 
-    DEFAULT_SOURCES = [['omgeo.services.EsriWGS', {}],
-                       ['omgeo.services.Nominatim', {}]
-                      ]
+    DEFAULT_SOURCES = [
+        ['omgeo.services.EsriWGS', {}],
+        ['omgeo.services.Nominatim', {}]
+    ]
     DEFAULT_PREPROCESSORS = []
     DEFAULT_POSTPROCESSORS = [
         SnapPoints(),
@@ -96,7 +96,6 @@ class Geocoder():
                    * upstream_response_info - list of UpstreamResponseInfo objects
         """
 
-        start_time = time.time()
         waterfall = self.waterfall if waterfall is None else waterfall
         if type(pq) in (str, str):
             pq = PlaceQuery(pq)
@@ -104,8 +103,6 @@ class Geocoder():
 
         for p in self._preprocessors:  # apply universal address preprocessing
             processed_pq = p.process(processed_pq)
-            if not processed_pq:
-                return get_result()  # universal preprocessor rejects PlaceQuery
 
         upstream_response_info_list = []
         processed_candidates = []

--- a/omgeo/places.py
+++ b/omgeo/places.py
@@ -101,13 +101,13 @@ class Viewbox():
             padding = num_spaces * ' '
             return '%s%s' % (padding, str_)
 
-        return    '          %s\n'\
-                  '        ------------\n'\
-                  '        |          |\n'\
-                  '%s|          |%s\n'\
-                  '        |          |\n'\
-                  '        ------------\n'\
-                  '          %s' % (lbl(top, 'C'), lbl(left, 'R'), lbl(right, 'L'), lbl(bottom, 'C'))
+        return '          %s\n'\
+               '        ------------\n'\
+               '        |          |\n'\
+               '%s|          |%s\n'\
+               '        |          |\n'\
+               '        ------------\n'\
+               '          %s' % (lbl(top, 'C'), lbl(left, 'R'), lbl(right, 'L'), lbl(bottom, 'C'))
 
 
 class PlaceQuery():

--- a/omgeo/postprocessors.py
+++ b/omgeo/postprocessors.py
@@ -418,7 +418,6 @@ class DupePicker(_PostProcessor):
             attr_match = self.attr_dupes
             attr_match_test_val = cleanup(getattr(hsc, attr_match))
             # make a list of candidates that have essentially the same value for attr_match (like 123 Main & 123 MAIN)
-            #import IPython; IPython.embed()
             matching_candidates = [mc for mc in candidates if cleanup(getattr(mc, attr_match)) == attr_match_test_val]
             # sort them in the desired order so the first one has the best attribute value
             matching_candidates = AttrSorter(self.ordered_list, self.attr_sort).process(matching_candidates)
@@ -522,11 +521,11 @@ class SnapPoints(_PostProcessor):
         lat1, lon1 = pnt1
         lat2, lon2 = pnt2
         radius = 6356752  # km
-        dlat = math.radians(lat2-lat1)
-        dlon = math.radians(lon2-lon1)
-        a = math.sin(dlat/2) * math.sin(dlat/2) + math.cos(math.radians(lat1)) \
-            * math.cos(math.radians(lat2)) * math.sin(dlon/2) * math.sin(dlon/2)
-        c = 2 * math.atan2(math.sqrt(a), math.sqrt(1-a))
+        dlat = math.radians(lat2 - lat1)
+        dlon = math.radians(lon2 - lon1)
+        a = math.sin(dlat / 2) * math.sin(dlat / 2) + math.cos(math.radians(lat1)) \
+            * math.cos(math.radians(lat2)) * math.sin(dlon / 2) * math.sin(dlon / 2)
+        c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
         d = radius * c
         return d
 

--- a/omgeo/postprocessors.py
+++ b/omgeo/postprocessors.py
@@ -271,7 +271,7 @@ class AttrMigrator(_PostProcessor):
 
 class AttrFilter(_PostProcessor):
     """
-    PostProcessor used to ditch results with unwanted attribute values.
+    PostProcessor used to filter out results without desired attribute values.
     """
 
     def __init__(self, good_values=[], attr='locator', exact_match=True):
@@ -301,7 +301,7 @@ class AttrFilter(_PostProcessor):
 
 class AttrExclude(_PostProcessor):
     """
-    PostProcessor used to ditch results with unwanted attribute values.
+    PostProcessor used to filter out results with unwanted attribute values.
     """
 
     def __init__(self, bad_values=[], attr='locator', exact_match=True):
@@ -327,6 +327,54 @@ class AttrExclude(_PostProcessor):
     def __repr__(self):
         return '<%s: %s %s in %s>' % \
             (self.__class__.__name__, self.is_exact(), self.attr, self.bad_values)
+
+
+class AttrListIncludes(_PostProcessor):
+    """
+    PostProcessor used to filter out results without desired attribute list items.
+
+    Similar to `AttrFilter` but operates on attributes containing lists instead of scalar values.
+    """
+
+    def __init__(self, good_values=[], attr='entity_types'):
+        """
+        :arg list good_values: A list of values, one of which must be in the
+                               attribute being filtered on (default [])
+        :arg string attr: The attribute on which to filter
+        """
+        self._init_helper(vars())
+
+    def process(self, candidates):
+        return [c for c in candidates if any(gv in getattr(c, self.attr)
+                                             for gv in self.good_values)]
+
+    def __repr__(self):
+        return '<%s: %s %s in %s>' % \
+            (self.__class__.__name__, self.attr, self.good_values)
+
+
+class AttrListExcludes(_PostProcessor):
+    """
+    PostProcessor used to ditch results with unwanted attribute list items.
+
+    Similar to `AttrExclude` but operates on attributes containing lists instead of scalar values.
+    """
+
+    def __init__(self, bad_values=[], attr='entity_types'):
+        """
+        :arg list bad_values: A list of values, which cannot be in the
+                              attribute being filtered on (default [])
+        :arg string attr: The attribute on which to filter
+        """
+        self._init_helper(vars())
+
+    def process(self, candidates):
+        return [c for c in candidates if not any(bv in getattr(c, self.attr)
+                                                 for bv in self.bad_values)]
+
+    def __repr__(self):
+        return '<%s: %s %s in %s>' % \
+            (self.__class__.__name__, self.attr, self.bad_values)
 
 
 class DupePicker(_PostProcessor):

--- a/omgeo/preprocessors.py
+++ b/omgeo/preprocessors.py
@@ -161,7 +161,7 @@ class CountryPreProcessor(_PreProcessor):
                                For example, suppose that the geocoding service recognizes
                                'GB', but not 'UK' -- and 'US', but not 'USA'::
 
-                                    country_map = {'UK':'GB', 'USA':'US'} 
+                                    country_map = {'UK':'GB', 'USA':'US'}
 
         """
         self.acceptable_countries = acceptable_countries if acceptable_countries is not None else []

--- a/omgeo/services/__init__.py
+++ b/omgeo/services/__init__.py
@@ -1,3 +1,4 @@
+# flake8: noqa: F401
 from .bing import Bing
 from .esri import EsriWGS
 from .us_census import USCensus

--- a/omgeo/services/base.py
+++ b/omgeo/services/base.py
@@ -7,12 +7,6 @@ from xml.dom import minidom
 
 import requests
 
-try:
-    # python 3
-    from urllib.parse import urlencode
-except ImportError:
-    # python 2
-    from urllib import urlencode
 
 logger = logging.getLogger(__name__)
 
@@ -226,7 +220,7 @@ class GeocodeService():
             end = datetime.now()
             response_time_sec = (end - start).total_seconds()
             upstream_response_info.set_response_time(1000 * response_time_sec)
-        except:
+        except Exception:
             upstream_response_info.set_success(False)
             upstream_response_info.errors.append(format_exc())
             return [], upstream_response_info

--- a/omgeo/services/nominatim.py
+++ b/omgeo/services/nominatim.py
@@ -20,7 +20,7 @@ class Nominatim(GeocodeService):
                                  'leisure.sports_centre', 'lesiure.stadium', 'leisure.track',
                                  'lesiure.water_park', 'man_made.lighthouse', 'man_made.works',
                                  'military.barracks', 'military.bunker', 'office.', 'place.house',
-                                 'amenity.',  'power.generator', 'railway.station',
+                                 'amenity.', 'power.generator', 'railway.station',
                                  'shop.', 'tourism.']
 
     DEFAULT_REJECTED_ENTITIES = ['amenity.drinking_water',

--- a/omgeo/tests/tests.py
+++ b/omgeo/tests/tests.py
@@ -286,7 +286,8 @@ class GeocoderTest(OmgeoTestCase):
         """
         candidates = self.g_bing.get_candidates(self.pq['karori'])
         self.assertEqual(len(candidates) > 0, True, 'No candidates returned.')
-        self.assertEqual(any([('102' in c.match_addr and '6012' in c.match_addr) for c in candidates]),
+        self.assertEqual(
+            any([('102' in c.match_addr and '6012' in c.match_addr) for c in candidates]),
             True, 'Could not find bldg. no. "102" and postcode "6012" in any address.')
 
     def _test_address_components(self, candidate):
@@ -314,10 +315,12 @@ class GeocoderTest(OmgeoTestCase):
             else:
                 queries_with_results += 1
                 logger.info('Input:  %s' % self.pq[place].query)
-                logger.info(['Output: %r (%s %s)\n' %
-                                (c.match_addr,
-                                 c.geoservice,
-                                 [c.locator, c.score, c.confidence, c.entity]) for c in candidates])
+                logger.info([
+                    'Output: %r (%s %s)\n' % (
+                        c.match_addr,
+                        c.geoservice,
+                        [c.locator, c.score, c.confidence, c.entity])
+                    for c in candidates])
         self.assertEqual(expected_results, queries_with_results,
                          'Got results for %d of %d queries.' % (queries_with_results, len(self.pq)))
 

--- a/omgeo/tests/tests.py
+++ b/omgeo/tests/tests.py
@@ -378,6 +378,10 @@ class GeocoderProcessorTest(OmgeoTestCase):
                                      score=99.9, x=-75.163, y=39.959)  # same y
         self.reading_term = Candidate(match_addr='1200 Arch St', locator='rooftop',
                                       score=99.9, x=-75.163, y=39.953)  # same x
+        self.with_address_types = Candidate(match_addr='123 Any St', locator='address',
+                                            entity_types=['address', 'place'])
+        self.with_nonsense_types = Candidate(match_addr='123 Any St', locator='address',
+                                             entity_types=['house', 'building'])
 
         self.locators_worse_to_better = ['address', 'parcel', 'rooftop']
 
@@ -591,6 +595,22 @@ class GeocoderProcessorTest(OmgeoTestCase):
                                    x=-75.158303781, y=39.959040684)]  # about 40m away
         candidates_exp = [candidates_in[0]]  # should just keep the first one.
         candidates_out = SnapPoints(distance=50).process(candidates_in)
+        self.assertEqual_(candidates_out, candidates_exp)
+
+    def test_pro_filter_AttrListIncludes(self):
+        """Test AttrListIncludes postprocessor."""
+        good_values = ['address']
+        candidates_in = [self.with_address_types, self.with_nonsense_types]
+        candidates_exp = [self.with_address_types]
+        candidates_out = AttrListIncludes(good_values, 'entity_types').process(candidates_in)
+        self.assertEqual_(candidates_out, candidates_exp)
+
+    def test_pro_filter_AttrListExcludes(self):
+        """Test AttrListExcludes postprocessor."""
+        bad_values = ['house']
+        candidates_in = [self.with_address_types, self.with_nonsense_types]
+        candidates_exp = [self.with_address_types]
+        candidates_out = AttrListExcludes(bad_values, 'entity_types').process(candidates_in)
         self.assertEqual_(candidates_out, candidates_exp)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E501
+exclude = sphinx,build

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setup(
     install_requires=[
         'requests >= 2.18',
     ],
+    setup_requires=['flake8'],
     test_suite='omgeo.tests.tests',
 )


### PR DESCRIPTION
If there's a web site that associates a name with a business address, the Google geocoding service will use that information to attempt to geocode the person's name.

Since this is mostly unwanted behavior, I've added a default post-processor to remove these results.