### PR TITLE
Move flake8 to 'tests_require' in setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 
 script:
   - python setup.py test
-  - python setup.py flake8
+  - flake8
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ python:
   - '2.7'
   - '3.6'
 
+before_script:
+  - pip install flake8
+
 script:
-  - python setup.py test
   - flake8
+  - python setup.py test
 
 deploy:
   provider: pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - '3.6'
 
 script:
-  - python setup.py flake8
   - python setup.py test
+  - python setup.py flake8
 
 deploy:
   provider: pypi

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     install_requires=[
         'requests >= 2.18',
     ],
-    setup_requires=['flake8'],
     test_suite='omgeo.tests.tests',
+    tests_require=['flake8'],
 )

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,4 @@ setup(
         'requests >= 2.18',
     ],
     test_suite='omgeo.tests.tests',
-    tests_require=['flake8'],
 )


### PR DESCRIPTION
Flake8 shouldn't be required for production uses of the package, but putting it in `setup_requires` causes it to be installed (or to crash while trying to install, in some cases).  I believe `tests_require` is a more appropriate place for it.