### PR TITLE
Move flake8 installation from setup.py to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ python:
   - '2.7'
   - '3.6'
 
+before_script:
+  - pip install flake8
+
 script:
-  - python setup.py flake8
+  - flake8
   - python setup.py test
 
 deploy:

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,5 @@ setup(
     install_requires=[
         'requests >= 2.18',
     ],
-    setup_requires=['flake8'],
     test_suite='omgeo.tests.tests',
 )


### PR DESCRIPTION
Flake8 shouldn't be required for production installation, but putting it in `setup_requires` causes it to be installed (or to crash while trying to install, in some cases).
Just installing it and running it within the Travis config avoids any problems around around how to specify it in setup.py.

I hadn't seen issue #55, I just started poking at this in hopes that it would be a quick fix since it's blocking the Cicero build.  This seems like a good answer to me--making linting happen entirely in CI, rather than introducing any kind of package dependency for it.

Replaces PR #56 
Resolves #55 