### PR TITLE
Improve string type checking and compatibility

### DIFF
--- a/omgeo/geocoder.py
+++ b/omgeo/geocoder.py
@@ -6,6 +6,12 @@ from omgeo.postprocessors import DupePicker, SnapPoints
 logger = logging.getLogger(__name__)
 stats_logger = logging.getLogger('omgeo.stats')
 
+# Python 2/3 compatibility: set up 'unicode' for use in string type checking
+try:
+    unicode
+except NameError:
+    unicode = str
+
 
 class Geocoder():
     """
@@ -97,7 +103,7 @@ class Geocoder():
         """
 
         waterfall = self.waterfall if waterfall is None else waterfall
-        if type(pq) in (str, str):
+        if type(pq) in (str, unicode):
             pq = PlaceQuery(pq)
         processed_pq = copy.copy(pq)
 

--- a/omgeo/postprocessors.py
+++ b/omgeo/postprocessors.py
@@ -2,6 +2,12 @@ from omgeo.processor import _Processor
 import math
 from operator import attrgetter
 
+# Python 2/3 compatibility: set up 'unicode' for use in string type checking
+try:
+    unicode
+except NameError:
+    unicode = str
+
 
 class _PostProcessor(_Processor):
     """Takes, processes, and returns list of geocoding.places.Candidate objects."""
@@ -451,7 +457,7 @@ class DupePicker(_PostProcessor):
     def process(self, candidates):
         def cleanup(str_):
             """Returns string in uppercase and free of commas."""
-            if type(str_) in [str, str]:
+            if type(str_) in (str, unicode):
                 return str_.replace(',', '').upper()
             return str_
 

--- a/omgeo/tests/tests.py
+++ b/omgeo/tests/tests.py
@@ -434,6 +434,31 @@ class GeocoderProcessorTest(OmgeoTestCase):
         place_exp = place_in  # we should still have it because PO BOX does not match exactly
         self.assertEqual_(place_out, place_exp)
 
+    def test_pro_CancelIfRegexInAttr_all_unicode(self):
+        """Test CancelIfRegexInAttr preprocessor using unicode query, regex, and attrs."""
+        place_in = PlaceQuery(u'PO Box 123, Philadelphia, PA')
+        place_out = CancelIfRegexInAttr(regex=u"po box", attrs=(u'query',)).process(place_in)
+        place_exp = False
+        self.assertEqual_(place_out, place_exp)
+
+    def test_pro_CancelIfRegexInAttr_unicode_query(self):
+        """Test CancelIfRegexInAttr preprocessor using unicode query and default regex/attrs."""
+        place_in = PlaceQuery(u'PO Box 123, Philadelphia, PA')
+        place_out = CancelIfRegexInAttr(regex="po box", attrs=('query',)).process(place_in)
+        place_exp = False
+        self.assertEqual_(place_out, place_exp)
+
+    def test_pro_CancelIfRegexInAttr_unicode_args(self):
+        """Test CancelIfRegexInAttr preprocessor using bytestring query and unicode regex/attrs."""
+        place_in = PlaceQuery(b'PO Box 123, Philadelphia, PA')
+        # Test all 3 combinations for completeness, but only test the result once since if they
+        # fail it will be by raising exceptions
+        place_out = CancelIfRegexInAttr(regex=u"po box", attrs=('query',)).process(place_in)
+        place_out = CancelIfRegexInAttr(regex="po box", attrs=(u'query',)).process(place_in)
+        place_out = CancelIfRegexInAttr(regex=u"po box", attrs=('query',)).process(place_in)
+        place_exp = False
+        self.assertEqual_(place_out, place_exp)
+
     def test_pro_CancelIfPOBox(self):
         """Test CancelIfPOBox preprocessor."""
         place_in = PlaceQuery('PO Box 123, Philadelphia, PA')


### PR DESCRIPTION
One of the tests in Cicero, when running under Python 3, is using OMGeo with a PlaceQuery full of bytestring attributes.  Which causes a crash:
>   File "/usr/local/lib/python3.7/dist-packages/omgeo/geocoder.py", line 116, in geocode                       
    candidates, upstream_response_info = gs.geocode(processed_pq)                                             
  File "/usr/local/lib/python3.7/dist-packages/omgeo/services/base.py", line 211, in geocode                  
    processed_pq = p.process(processed_pq)                                                                    
  File "/usr/local/lib/python3.7/dist-packages/omgeo/preprocessors.py", line 244, in process                  
    return CancelIfRegexInAttr(regex, ('address', 'query')).process(pq)                                       
  File "/usr/local/lib/python3.7/dist-packages/omgeo/preprocessors.py", line 226, in process                  
    if any([self.regex.match(attr) is not None for attr in attrs]):                                           
  File "/usr/local/lib/python3.7/dist-packages/omgeo/preprocessors.py", line 226, in <listcomp>               
    if any([self.regex.match(attr) is not None for attr in attrs]):                                           
TypeError: cannot use a string pattern on a bytes-like object                                                 

In the course of trying to resolve the issue, I also ran afoul of the string type checking conditions in `CancelIfRegexInAttr.__init__()`, which were requiring that the type be `in (str, str)`.  That got changed from `(str, unicode)` in PR #47, and not allowing strings of type `unicode` is not ideal.  So I changed it back to `(str, unicode)` using a workaround--importing `str` as `unicode` in Python 3--that's Py2/Py3 compatible without requiring a dependency on `six` or `future`.

That didn't actually fix my original issue, though.  For that, I added an `except TypeError` to try the failing comparison on a `decode`ed version of the attribute if it fails on the provided version.

I also added a few tests to cover this issue.  They might not be fully comprehensive, but they do fail without the code changes (in both Py2 and Py3, for different reasons) and pass with the changes.
