### PR TITLE
Fix template strings in filter class __repr__ methods

### DIFF
--- a/omgeo/postprocessors.py
+++ b/omgeo/postprocessors.py
@@ -355,7 +355,7 @@ class AttrListIncludes(_PostProcessor):
                                              for gv in self.good_values)]
 
     def __repr__(self):
-        return '<%s: %s %s in %s>' % \
+        return '<%s: %s in %s>' % \
             (self.__class__.__name__, self.attr, self.good_values)
 
 
@@ -379,7 +379,7 @@ class AttrListExcludes(_PostProcessor):
                                                  for bv in self.bad_values)]
 
     def __repr__(self):
-        return '<%s: %s %s in %s>' % \
+        return '<%s: %s in %s>' % \
             (self.__class__.__name__, self.attr, self.bad_values)
 
 

--- a/omgeo/preprocessors.py
+++ b/omgeo/preprocessors.py
@@ -228,7 +228,7 @@ class CancelIfRegexInAttr(_PreProcessor):
             try:
                 match = self.regex.match(attr)
             except TypeError:
-                match = self.regex.match(attr.decode())
+                match = self.regex.match(attr.decode("utf-8"))
             if match is not None:
                 return False  # don't return the placequery if any match is found
         return pq

--- a/omgeo/tests/tests.py
+++ b/omgeo/tests/tests.py
@@ -436,21 +436,21 @@ class GeocoderProcessorTest(OmgeoTestCase):
 
     def test_pro_CancelIfRegexInAttr_all_unicode(self):
         """Test CancelIfRegexInAttr preprocessor using unicode query, regex, and attrs."""
-        place_in = PlaceQuery(u'PO Box 123, Philadelphia, PA')
+        place_in = PlaceQuery(u'PO Box 123, Lindström, MN')
         place_out = CancelIfRegexInAttr(regex=u"po box", attrs=(u'query',)).process(place_in)
         place_exp = False
         self.assertEqual_(place_out, place_exp)
 
     def test_pro_CancelIfRegexInAttr_unicode_query(self):
         """Test CancelIfRegexInAttr preprocessor using unicode query and default regex/attrs."""
-        place_in = PlaceQuery(u'PO Box 123, Philadelphia, PA')
+        place_in = PlaceQuery(u'PO Box 123, Lindström, MN')
         place_out = CancelIfRegexInAttr(regex="po box", attrs=('query',)).process(place_in)
         place_exp = False
         self.assertEqual_(place_out, place_exp)
 
     def test_pro_CancelIfRegexInAttr_unicode_args(self):
         """Test CancelIfRegexInAttr preprocessor using bytestring query and unicode regex/attrs."""
-        place_in = PlaceQuery(b'PO Box 123, Philadelphia, PA')
+        place_in = PlaceQuery(u'PO Box 123, Lindström, MN'.encode("utf-8"))
         # Test all 3 combinations for completeness, but only test the result once since if they
         # fail it will be by raising exceptions
         place_out = CancelIfRegexInAttr(regex=u"po box", attrs=('query',)).process(place_in)


### PR DESCRIPTION
While trying to debug an encoding problem in Cicero, I ended up digging into OMGeo again, and in the process discovered that just trying to examine the geocoder settings caused an error from [`postprocessors.py`](https://github.com/azavea/python-omgeo/blob/6.0.3/omgeo/postprocessors.py#L383):
> TypeError: not enough arguments for format string

Looks like the `AttrListIncludes` and `AttrListExcludes` filter classes were based off similar ones that had one additional parameter.

So this fixes that, and also:
- Changes `.decode()` calls to explicitly specify `"utf-8"` rather than rely on the default, which could potentially cause problems, as [noted by @ddohler on PR #61](https://github.com/azavea/python-omgeo/pull/61#discussion_r334910782)
- Adds a non-ASCII character to the test address in the `CancelIfRegexInAttr` tests, since it's easier for problems to slip through the cracks if all the strings are ASCII-compatible.

None of this is urgent--the Cicero issue turned out not to implicate this package after all--but it might as well go in.

### Testing

- In a Python shell, run:
  ```
  from omgeo.postprocessors import AttrListExcludes
  AttrListExcludes(["foo"], "bar")
  ```
  With these changes it will print `<AttrListExcludes: bar in ['foo']>`.  Without, it will crash.
- `./test.sh` should succeed as before.
- I don't know of a way to test the explicit `decode` argument. As noted in the linked comment, we didn't manage to actually get something to break because of the default encoding.
