### PR TITLE
Use RegionAbbr for match_region with Esri WGS

### DIFF
--- a/omgeo/services/esri.py
+++ b/omgeo/services/esri.py
@@ -126,7 +126,7 @@ class EsriWGS(GeocodeService):
                      # 'AddBldg',
                      'City',
                      'Subregion',
-                     'Region',
+                     'RegionAbbr',
                      'Postal',
                      'Country',
                      # 'Ymax',
@@ -205,7 +205,7 @@ class EsriWGS(GeocodeService):
 
                 # Optional address component fields.
                 for in_key, out_key in [('City', 'match_city'), ('Subregion', 'match_subregion'),
-                                        ('Region', 'match_region'), ('Postal', 'match_postal'),
+                                        ('RegionAbbr', 'match_region'), ('Postal', 'match_postal'),
                                         ('Country', 'match_country')]:
                     setattr(c, out_key, attributes.get(in_key, ''))
                 setattr(c, 'match_streetaddr', self._street_addr_from_response(attributes))

--- a/omgeo/tests/tests.py
+++ b/omgeo/tests/tests.py
@@ -224,6 +224,16 @@ class GeocoderTest(OmgeoTestCase):
         candidates = self.g_esri_wgs_auth.get_candidates(self.pq['azavea'])
         self.assertOneCandidate(candidates)
 
+    def test_esri_short_region(self):
+        """Ensure that Esri uses region abbreviations"""
+        candidate = self.g_esri_wgs.get_candidates(self.pq["azavea"])[0]
+        self.assertEqual(candidate.match_region, "PA")
+
+    def test_google_short_region(self):
+        """Ensure that Google uses region abbreviations"""
+        candidate = self.g_google.get_candidates(self.pq["azavea"])[0]
+        self.assertEqual(candidate.match_region, "PA")
+
     @unittest.skipIf(BING_MAPS_API_KEY is None, BING_KEY_REQUIRED_MSG)
     def test_geocode_bing(self):
         """Test Azavea's address using Bing geocoder"""


### PR DESCRIPTION
## Overview

Previously, we were using Esri WGS's `Region` to populate `match_region`, but it provides the full name of the region, e.g. "Pennsylvania", rather than the abbrevation ("PA"), which is what most people expect, and which is contained in the `RegionAbbr` field. Additionally, we use the equivalent field to `RegionAbbr` to populate `match_region` with the Google geocoder ("short_name"), so the two sources provided very different data in `match_region`. This switches to use the `RegionAbbr` field for `match_region` with Esri WGS, which should be more user-friendly and will match the output from Google better (although neither one documents the format for their respective "short" fields, so there's no guarantee that they'll always match).

## Notes
- CI may fail -- I believe I configured my local environment with the same service credentials that are in CI, and I got a consistent failure from the Esri authentication test. I'll address that if it does.
- I'd be interested to hear feedback on what the version number for the next release should be. Switching from a text description to an abbreviation of region would likely be a breaking change to anyone who was relying on the current Esri `match_region` behavior.
- I included a test for Google's use of `short_name` because the reason why this was discovered was that there was a mismatch between the Esri and Google behavior, so that seemed worth enforcing. However, I didn't try to ensure that every geocoder behaves the same way because Esri and Google are the most heavily used and not all the other geocoders are structured in a way that provides control over region abbrevations. But I could take a look at doing that if it would be valuable.

## Testing instructions
- Running tests should be all that's necessary, but if you want you can revert the changes to `esri.py` and confirm that it triggers a failure.