### PR TITLE
Fix magicKey breaking ESRI geocoding

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Run tests
         run: python setup.py test
-        env:
-          BING_MAPS_API_KEY: ${{ secrets.BING_MAPS_API_KEY }}
-          ESRI_CLIENT_ID: ${{ secrets.ESRI_CLIENT_ID }}
-          ESRI_CLIENT_SECRET: ${{ secrets.ESRI_CLIENT_SECRET }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          MAPQUEST_API_KEY: ${{ secrets.MAPQUEST_API_KEY }}
-          PELIAS_API_KEY: ${{ secrets.PELIAS_API_KEY }}
+        # env:
+          # BING_MAPS_API_KEY: ${{ secrets.BING_MAPS_API_KEY }}
+          # ESRI_CLIENT_ID: ${{ secrets.ESRI_CLIENT_ID }}
+          # ESRI_CLIENT_SECRET: ${{ secrets.ESRI_CLIENT_SECRET }}
+          # GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          # MAPQUEST_API_KEY: ${{ secrets.MAPQUEST_API_KEY }}
+          # PELIAS_API_KEY: ${{ secrets.PELIAS_API_KEY }}
 

--- a/omgeo/services/esri.py
+++ b/omgeo/services/esri.py
@@ -55,6 +55,7 @@ class EsriWGS(GeocodeService):
     DEFAULT_POSTPROCESSORS = [
         AttrFilter(['PointAddress',
                     'StreetAddress',
+                    'Locality',
                     # 'PostalExt',
                     # 'Postal'
                     ],
@@ -62,6 +63,7 @@ class EsriWGS(GeocodeService):
         # AttrExclude(['USA_Postal'], 'locator'), #accept postal from everywhere but US (need PostalExt)
         AttrSorter(['PointAddress',
                     'StreetAddress',
+                    'Locality',
                     # 'PostalExt',
                     # 'Postal'
                     ],

--- a/omgeo/services/esri.py
+++ b/omgeo/services/esri.py
@@ -195,7 +195,7 @@ class EsriWGS(GeocodeService):
                 c = Candidate()
                 attributes = location['attributes']
                 c.match_addr = attributes['Match_addr']
-                c.locator = attributes['Loc_name']
+                c.locator = attributes.get('Loc_name', '')
                 c.locator_type = attributes['Addr_type']
                 c.score = attributes['Score']
                 c.x = attributes['DisplayX']  # represents the actual location of the address.
@@ -210,7 +210,8 @@ class EsriWGS(GeocodeService):
                     setattr(c, out_key, attributes.get(in_key, ''))
                 setattr(c, 'match_streetaddr', self._street_addr_from_response(attributes))
                 returned_candidates.append(c)
-        except KeyError:
+        except KeyError as e:
+            logger.warning('Missing key: ' + e)
             pass
         return returned_candidates
 

--- a/omgeo/tests/tests.py
+++ b/omgeo/tests/tests.py
@@ -208,6 +208,16 @@ class GeocoderTest(OmgeoTestCase):
         self.assertEqual('340 N 12th' in candidates[0].match_addr, True,
                          '"340 N 12th" not found in match_addr. Got "%s"' % candidates[0].match_addr)
 
+    def test_geocode_esri_wgs_magicKey(self):
+        """Check that geocoding New York, USA with a magicKey returns one result."""
+        esri = self.g_esri_wgs._sources[0]
+        suggestions = esri._get_json_obj(
+            f'{esri._endpoint}/suggest',
+            {'f': 'json', 'text': 'New York, USA'})['suggestions']
+        pq = PlaceQuery(suggestions[0]['text'], key=suggestions[0]['magicKey'])
+        candidates = self.g_esri_wgs.get_candidates(pq)
+        self.assertOneCandidate(candidates)
+
     def test_geocode_esri_wgs_zip_plus_4(self):
         """Check that geocoding 19127-1112 returns one result."""
         candidates = self.g_esri_wgs_postal_ok.get_candidates(self.pq['zip_plus_4_in_postal_plus_country'])

--- a/omgeo/tests/tests.py
+++ b/omgeo/tests/tests.py
@@ -239,6 +239,7 @@ class GeocoderTest(OmgeoTestCase):
         candidate = self.g_esri_wgs.get_candidates(self.pq["azavea"])[0]
         self.assertEqual(candidate.match_region, "PA")
 
+    @unittest.skipIf(GOOGLE_API_KEY is None, GOOGLE_KEY_REQUIRED_MSG)
     def test_google_short_region(self):
         """Ensure that Google uses region abbreviations"""
         candidate = self.g_google.get_candidates(self.pq["azavea"])[0]
@@ -282,8 +283,8 @@ class GeocoderTest(OmgeoTestCase):
         self.assertEqual(len(candidates) > 0, True, 'No candidates returned.')
 
     def test_geocode_census(self):
-        """Test Azavea's address using US Census geocoder."""
-        candidates = self.g_census.get_candidates(PlaceQuery('1200 Callowhill St, Philadelphia, PA'))
+        """Test Element 84's address using US Census geocoder."""
+        candidates = self.g_census.get_candidates(PlaceQuery('210 N. Lee Street, Alexandria, VA'))
         self.assertEqual(len(candidates) > 0, True, 'No candidates returned.')
 
     def test_EsriWGS_address_components(self):


### PR DESCRIPTION
## Overview

At some point the ESRI `/findAddressCandidates` endpoint stopped returning the `Loc_name` attribute if `magicKey` is specified. Since the endpoint is not open source and they don't seem to have a changelog that I could find, I don't know exactly when this happened, but reports in MMW (https://github.com/WikiWatershed/model-my-watershed/issues/3604, https://github.com/WikiWatershed/model-my-watershed/issues/3605) seem to indicate it has been the case for a while.

This fixes that by making that attribute optional.

Also adds a test for this. Also adds warning logging for when other keys are missing.

## Demo

You can see MMW production not working using the main library, and my local version that uses this branch's omgeo working correctly:

https://github.com/azavea/python-omgeo/assets/1430060/74a6f48e-f058-4015-8a80-1ab36b7569b4


Closes #67 