### PR TITLE
Update PyPI Integrations for Release Upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout commit and fetch tag history
         uses: actions/checkout@v2
@@ -25,10 +27,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
 
-      - name: Build and publish package
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_AZAVEA_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_AZAVEA_PASSWORD }}
-        run: |
-          python setup.py sdist bdist_wheel
-          twine upload dist/*
+      - name: Build release package
+        run: python setup.py sdist bdist_wheel
+
+      - name: Upload release to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,5 @@ jobs:
       - name: Build release package
         run: python setup.py sdist bdist_wheel
 
-      - name: Upload release to TestPyPI
+      - name: Upload release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -235,3 +235,7 @@ v6.2.0, 2024-01-22
    previously would provide an internal Loc_name field in the response which
    is no longer supplied, which broke the API. Making that field optional in
    our code fixes this.
+
+v6.2.1, 2024-04-15
+------------------
+ * Update PyPI publishing integration

--- a/omgeo/tests/tests.py
+++ b/omgeo/tests/tests.py
@@ -179,7 +179,7 @@ class GeocoderTest(OmgeoTestCase):
         """
         candidates = self.g_esri_wgs.get_candidates(self.pq['senado_mx'])
         self.assertOneCandidate(candidates)
-        search_text = 'Paseo de la Reforma 135'
+        search_text = 'Paseo de La Reforma 135'
         self.assertEqual(search_text in candidates[0].match_addr, True,
                          '"%s" not found in match_addr. Got "%s".'
                          % (search_text, candidates[0].match_addr))
@@ -192,7 +192,7 @@ class GeocoderTest(OmgeoTestCase):
         """
         candidates = self.g_esri_wgs.get_candidates(self.pq['senado_mx_struct'])
         self.assertOneCandidate(candidates)
-        search_text = 'Paseo de la Reforma 135'
+        search_text = 'Paseo de La Reforma 135'
         self.assertEqual(search_text in candidates[0].match_addr, True,
                          '"%s" not found in match_addr. Got "%s".'
                          % (search_text, candidates[0].match_addr))


### PR DESCRIPTION
## Overview

The `python-omgeo` Python packages is published via the Azavea PyPI account, however recent builds of these projects are failing because PyPI has changed from username/password authentication to token based and trusted-publisher based authentication.  This PR will address updating the integration.

Closes #71 

### Demo

The Problem:
- [GitHub Action Release #5](https://github.com/azavea/python-omgeo/actions/runs/7631232087)
```
Uploading python_omgeo-6.2.1-py3-none-any.whl
25l
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/47.7 kB • --:-- • ?
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 47.7/47.7 kB • 00:00 • 145.3 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 47.7/47.7 kB • 00:00 • 145.3 MB/s
25hWARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 403 Forbidden from https://upload.pypi.org/legacy/          
         Username/Password authentication is no longer supported. Migrate to API
         Tokens or Trusted Publishers instead. See                              
         https://pypi.org/help/#apitoken and                                    
         https://pypi.org/help/#trusted-publishers                              
Error: Process completed with exit code 1.
```

Proposed Solution:
- [django-ecsmanage PyPI Integration](https://github.com/azavea/django-ecsmanage/blob/cee8ec1b361fae37f941381118d900010cf3478d/.github/workflows/release.yml#L33)
```
      - name: Upload release to TestPyPI
        uses: pypa/gh-action-pypi-publish@release/v1
```

### Notes

- Prior to merging this PR, TestPyPI and PyPI were updated to add a new publisher, as outlined in the workplan on Issue #71 
- After conducting a test upload to TestPyPI and confirming success, update the `workflow.yml` file by removing the `with:` clause from the **Upload release to TestPyPI** step and update the step name accordingly.  This will switch the upload from TestPyPI to PyPI.

## Testing Instructions

TestPyPI Testing - Manual Release:
> [!NOTE]
> Example of successful manual test: [GitHub Action Release #6](https://github.com/azavea/python-omgeo/actions/runs/8693618051/job/23840762347)
> Note that `upload` was misspelled in this test run, it has since been corrected.
- [x] 1. Create a manual test release branch off this one titled `release/test` with the tags `test`, then push up
```
git checkout -b release/test
git tag test
git push --set-upstream origin release/test
git push --tags
```
- [x] 2. Review the GitHub Action generated to see if it completes successfully
- [x] 3. Remove the tags from origin and the local branch
```
git tag -d test
git push --delete origin test
```

## Checklist

- [x] 1. `CHANGES.txt` has been updated
- [ ] 2. After merging, ensure a release workflow has been conducted
